### PR TITLE
fixed proj-owner name to automatically add issues to the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug
 labels: ["bug"]
-projects: ["c0dingviking/2"]
+projects: ["C0dingViking/2"]
 body:
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,7 +1,7 @@
 name: EPIC
 description: Create an EPIC
 labels: ["epic"]
-projects: ["c0dingviking/2"]
+projects: ["C0dingViking/2"]
 body:
   - type: textarea
     id: epic

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,7 +1,7 @@
 name: User Story
 description: Create a user story
 labels: ["user story"]
-projects: [c0dingviking/2]
+projects: [C0dingViking/2]
 body:
   - type: textarea
     id: user-story


### PR DESCRIPTION
Fixes bug where issues aren't added to the GitHub project automatically (#6).

The issue was caused by incorrect capitalization in the project owner's username in the URI.  
This PR corrects the capitalization so that the issue can be automatically added to the project.

Closes: #6 