### PR TITLE
[US-6.1] Map Markers Block Access to Building Information

### DIFF
--- a/concordia_campus_guide/lib/domain/interactors/map_data_interactor.dart
+++ b/concordia_campus_guide/lib/domain/interactors/map_data_interactor.dart
@@ -60,7 +60,6 @@ class MapDataInteractor {
           (final b) => Marker(
             markerId: MarkerId("${b.id}-marker"),
             position: _calculateBuildingCentroid(b.outlinePoints),
-            infoWindow: InfoWindow(title: b.name, snippet: b.address),
           ),
         )
         .toSet();

--- a/concordia_campus_guide/lib/ui/home/widgets/home_screen.dart
+++ b/concordia_campus_guide/lib/ui/home/widgets/home_screen.dart
@@ -98,6 +98,15 @@ class _HomeScreenState extends State<HomeScreen> {
   void _onBuildingTapped(final PolygonId polygonId) {
     // Extract building ID from polygon ID (format: "buildingId-poly")
     final buildingId = polygonId.value.replaceAll("-poly", "");
+    _navigateToBuilding(buildingId);
+  }
+
+  void _onBuildingMarkerTapped(final MarkerId markerId) {
+    final buildingId = markerId.value.replaceAll("-marker", "");
+    _navigateToBuilding(buildingId);
+  }
+
+  void _navigateToBuilding(final String buildingId) {
     final building = _viewModel.buildings[buildingId];
 
     if (building != null) {
@@ -326,6 +335,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   polylines: hvm.routePolylines,
                   circles: hvm.transitChangeCircles,
                   onPolygonTap: _onBuildingTapped,
+                  onMarkerTap: _onBuildingMarkerTapped,
                 ),
                 const Positioned(
                   left: searchBarInset,

--- a/concordia_campus_guide/lib/ui/home/widgets/map_wrapper.dart
+++ b/concordia_campus_guide/lib/ui/home/widgets/map_wrapper.dart
@@ -11,6 +11,7 @@ class MapWrapper extends StatelessWidget {
   final Set<Polyline> polylines;
   final Set<Circle> circles;
   final void Function(PolygonId)? onPolygonTap;
+  final void Function(MarkerId)? onMarkerTap;
 
   // These are the missing definitions
   final bool myLocationButtonEnabled;
@@ -28,6 +29,7 @@ class MapWrapper extends StatelessWidget {
     this.polylines = const {},
     this.circles = const {},
     this.onPolygonTap,
+    this.onMarkerTap,
     this.myLocationButtonEnabled = false,
     this.zoomControlsEnabled = false,
     this.fortyFiveDegreeImageryEnabled = false,
@@ -47,6 +49,17 @@ class MapWrapper extends StatelessWidget {
               .toSet()
         : polygons;
 
+    final Set<Marker> tappableMarkers = onMarkerTap != null
+        ? markers
+              .map(
+                (final marker) => marker.copyWith(
+                  onTapParam: () => onMarkerTap!(marker.markerId),
+                  consumeTapEventsParam: true,
+                ),
+              )
+              .toSet()
+        : markers;
+
     return GoogleMap(
       initialCameraPosition: initialCameraPosition,
       onMapCreated: onMapCreated,
@@ -55,7 +68,7 @@ class MapWrapper extends StatelessWidget {
       myLocationButtonEnabled: myLocationButtonEnabled,
       zoomControlsEnabled: zoomControlsEnabled,
       polygons: tappablePolygons,
-      markers: markers,
+      markers: tappableMarkers,
       polylines: polylines,
       circles: circles,
       fortyFiveDegreeImageryEnabled: fortyFiveDegreeImageryEnabled,

--- a/concordia_campus_guide/test/ui/home/widgets/home_screen_test.dart
+++ b/concordia_campus_guide/test/ui/home/widgets/home_screen_test.dart
@@ -530,5 +530,18 @@ void main() {
         expect(building, isNotNull);
       }
     });
+
+    testWidgets("building marker tap lookup finds correct building", (final tester) async {
+      await pumpHomeScreen(tester);
+
+      const markerId = MarkerId("H-marker");
+      final buildingId = markerId.value.replaceAll("-marker", "");
+      final building = vm.buildings[buildingId];
+
+      expect(buildingId, equals("H"));
+      expect(building, isNotNull);
+      expect(building?.id, equals("H"));
+      expect(building?.name, equals("Science Hall"));
+    });
   });
 }

--- a/concordia_campus_guide/test/ui/home/widgets/map_wrapper_test.dart
+++ b/concordia_campus_guide/test/ui/home/widgets/map_wrapper_test.dart
@@ -152,4 +152,37 @@ void main() {
       }
     });
   });
+
+  group("MapWrapper Marker Tap Tests", () {
+    testWidgets("MapWrapper accepts onMarkerTap callback", (final tester) async {
+      final testMarker = Marker(
+        markerId: const MarkerId("H-marker"),
+        position: const LatLng(45.497, -73.579),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MapWrapper(
+              initialCameraPosition: const CameraPosition(
+                target: LatLng(45.4972, -73.5786),
+                zoom: 15,
+              ),
+              onMapCreated: (_) {},
+              myLocationEnabled: false,
+              polygons: const {},
+              markers: {testMarker},
+              onMarkerTap: (final markerId) {
+                // Callback is provided to test it's accepted
+                expect(markerId.value, equals("H-marker"));
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(MapWrapper), findsOneWidget);
+      expect(find.byType(GoogleMap), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
# Solution 1
Navigate to building information page on marker click

- The marker doesn't do anything special anymore
- A click on the marker is equivalent to a click on any part of the highlighted region of a buildng

![output](https://github.com/user-attachments/assets/5cbf8078-98ac-466a-8ce6-07ae42a55119)

# Solution 2
An alternate solution is presented in b6a1b617655e28a3b9bd609a62bd0b3905030392

- The markers are hidden from the map altogether
- The user can access the building information page by clicking on any part of the highlighted region of a building

<img width="494" height="1040" alt="image" src="https://github.com/user-attachments/assets/2c1adc3a-40ce-4340-9a5b-f02d32d88c3b" />
